### PR TITLE
install nodejs using apt-get

### DIFF
--- a/rust-grcov/Dockerfile
+++ b/rust-grcov/Dockerfile
@@ -1,5 +1,9 @@
 FROM rust:1.69
 
+# Install nodejs
+RUN apt-get update && apt-get install -y \
+    nodejs
+
 # Install yarn
 RUN npm install -g yarn
 

--- a/rust-grcov/Dockerfile
+++ b/rust-grcov/Dockerfile
@@ -2,7 +2,8 @@ FROM rust:1.69
 
 # Install nodejs
 RUN apt-get update && apt-get install -y \
-    nodejs
+    nodejs \
+    npm
 
 # Install yarn
 RUN npm install -g yarn


### PR DESCRIPTION
We need to install `node` and `yarn` ourselves since the rust image we're starting from doesn't include them.